### PR TITLE
If user isnt logged in via facebook, get profile name

### DIFF
--- a/habitrpg-ncurses.js
+++ b/habitrpg-ncurses.js
@@ -32,7 +32,7 @@ var data = {
 };
 var refresh =  function(){
         request.get(fullapiurl + "/user").set('Accept', 'application/json').set('X-API-User', config.apiuser).set('X-API-Key', config.apitoken).end(function(res){
-        data.username = res.body.auth.local.username;
+        data.username = res.body.auth.local ? res.body.auth.local.username : res.body.profile.name;
         data.level = res.body.stats.lvl;
         data.health = Math.ceil(res.body.stats.hp);
         data.healthMax=50;


### PR DESCRIPTION
It threw an error for me when I tried using it due to the fact that I don't have an `auth.local` path. I log in via facebook. This checks your profile name if you don't have a `local` path so no error is thrown.
