### PR TITLE
Switch between emacs and vi keybindings, switch key detection to the keypress module.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,14 @@
 var conf = require('nconf'),
     tty = require('tty'),
     HabitAPI = require('./lib/habitapi.js'),
-    view = require('./lib/charmview.js');
+    view = require('./lib/charmview.js'),
+    keypress = require('keypress');
 
 conf.argv().file({file: __dirname + "/config.json"}).defaults({
     'APIURL': 'https://habitrpg.com/api/v1',
     'APIUSER': '001122',
     'APITOKEN': 'ABCABC',
+    'KEYBINDING': 'vi'
 });
 
 
@@ -19,69 +21,117 @@ if (typeof process.stdin.fd === 'number' && tty.isatty(process.stdin.fd)) {
 }
 process.stdin.resume();
 process.stdin.setEncoding('utf8');
-process.stdin.on("data", function(key){
-    key = "" + key;
-    if(key.charCodeAt() === 3){
+
+// Keypress doesn't detect the names some keys, so fall
+// back to plain sequence in those cases (ch).
+view.InputWindow.setKeybinding(conf.get("KEYBINDING"));
+keypress(process.stdin);
+process.stdin.on('keypress', function(ch, key){
+    if (key && key.ctrl && key.name == 'c') { // exit on C-c
         process.exit(0);
-    } else {
+    }
+    else if(key) {
+        keyPress(key);
+
+    } else {    
+        key = ch;
         keyPress(key);
     }
+    
     
 });
 
 function keyPress(key){
     view.LogWindow.keyPress(key);
-
+    var kb = view.InputWindow.getKeybinding();
     if(view.InputWindow.getMode() == 'normal'){
-        if(key === '~' || key === '`'){ // ~, `  toggle debug window
+        if(kb == 'vi') { 
+            if(key.name === '~' || key.name === '`'){ // ~, `  toggle debug window
 
-            view.LogWindow.toggle();
+                view.LogWindow.toggle();
 
-        } if(key == 'j'){ // j, up arrow: move up
+            } if(key.name == 'j'){ // j, up arrow: move up
 
-            view.TaskList.moveCursor(1);
+                view.TaskList.moveCursor(1);
 
-        } else if(key == 'k'){ // k, down arrow : move down
+            } else if(key.name == 'k'){ // k, down arrow : move down
 
-            view.TaskList.moveCursor(-1);
+                view.TaskList.moveCursor(-1);
 
-        } else if(key == 'J'){ // J move one section down
-
-
-        } else if(key == 'K'){ // K  move one section up
+            } else if(key.name == 'J'){ // J move one section down
 
 
-        } else if(key == 'X' || key == 'x' || key == ' '){ // X and Space
+            } else if(key.name == 'K'){ // K  move one section up
 
-            view.TaskList.checkItem();
+            } else if(key.name == 'd' || key == '-'){ // d, minus to decrement whatever you are on
 
-        } else if(key == 'd' || key == '-'){ // d, minus to decrement whatever you are on
+                view.TaskList.decrementHabit();
 
-            view.TaskList.decrementHabit();
+            } else if(key.name == 'space' || key.name == 'x'){ // update habit
 
-        } else if(key == 'r'){ // r, manual refresh 
+                view.TaskList.checkItem();
 
-            HabitAPI.refresh();
+            } else if(key.name == 'r'){ // r, manual refresh 
 
-        }  else if(key == '?'){
+                HabitAPI.refresh();
 
-            view.HelpWindow.toggle();
+            }  else if(key == '?'){
 
-        }  else if(key == ":"){
-            view.InputWindow.setMode('command');
+                view.HelpWindow.toggle();
 
-        } else if(key == "/"){
-            view.InputWindow.setMode('search');
+            }  else if(key == ":"){
+                view.InputWindow.setMode('command');
 
+            } else if(key == "/"){
+                view.InputWindow.setMode('search');
+
+            }
+        }
+        if(kb == 'emacs'){
+            if(key == '`' || key == '~' || key.name == 'f1'){ // f1,  toggle debug window
+
+                view.LogWindow.toggle();
+
+            }
+
+            if(key.name == 'n'){ // n or C-n
+
+                view.TaskList.moveCursor(1);
+
+            } else if(key.name == 'p'){ // p or C-p
+
+                view.TaskList.moveCursor(-1);
+
+            } else if(key.ctrl && key.name == 'd'){ // C-d to decrement whatever you are on
+
+                view.TaskList.decrementHabit();
+
+            } else if(key.ctrl && (key.name == 'space' || key.name == '`')){ // C-SPC, C-`
+
+                view.TaskList.checkItem();
+
+            } else if(key.name == 'r'){ // r, manual refresh 
+
+                HabitAPI.refresh();
+
+            }  else if(key == '?'){ // ? for help
+
+                view.HelpWindow.toggle();
+
+            }  else if(key.meta && key.name == 'x'){ // M-x
+                view.InputWindow.setMode('command');
+
+            } else if(key.ctrl && key.name == 's'){ // C-s
+                view.InputWindow.setMode('search');
+
+            }
         }
     }
-
     if(view.InputWindow.getMode() != 'normal'){
         // we are not in normal mode
         view.InputWindow.keyPress(key);
 
     }
-
 }
 
 

--- a/lib/charmview.js
+++ b/lib/charmview.js
@@ -2,7 +2,8 @@ var charm = require('charm')(),
     HabitAPI = require('./habitapi.js'),
     _ = require('underscore'),
     size = process.stdout.getWindowSize(),
-    COLORS=require('../colors.json');
+    COLORS=require('../colors.json'),
+    kb;
 
 charm.pipe(process.stdout);
 charm.reset();
@@ -42,42 +43,59 @@ var InputWindow = (function(){
     var inputMode = "normal",
         buffer = "";
 
+    function setKeybinding(_kb){
+        kb = _kb;
+    }
     function setMode(mode){
 
-       inputMode = mode; 
-       charm.position(0,size[1]);
-       if(inputMode === "command"){
-           charm.erase('line');
-           charm.cursor(true);
-       } else if(inputMode === "search"){
-           charm.erase('line');
-           charm.write(buffer);
-           charm.cursor(true);
-       } else {
-           charm.cursor(false);
-       }
+        inputMode = mode; 
+        charm.position(0,size[1]);
+        if(inputMode === "command"){
+            charm.erase('line');
+            if (kb == 'emacs')
+                buffer = "M-x ";
+            charm.cursor(true);
+            charm.write(buffer);
+
+        } else if(inputMode === "search"){
+            charm.erase('line');
+            if (kb == 'emacs')
+                buffer = "I-search: ";
+            charm.write(buffer);
+            charm.cursor(true);
+        } else {
+            charm.cursor(false);
+        }
 
     }
 
     return {
         setMode: setMode,
+        setKeybinding: setKeybinding,
+        getKeybinding: function(){
+            return kb;
+        },
         getMode: function(){
             return inputMode;
         },
         keyPress: function(key){
-            var i = 0;
+            var i = 0,
+                cmdpos;
+            if(kb == 'emacs')
+                cmdpos = 4;
+            else if(kb == 'vi')
+                cmdpos = 0;
             if(inputMode == 'normal'){
                 charm.cursor(false);
             } else {
-                if(key.charCodeAt(0) === 9){
-                    setMode('normal');
+                if(key.name == 'tab'){
+                setMode('normal');
 
-                } else if (key.charCodeAt() === 127 && buffer.length > 0) {
-
+                } else if (key.name === 'backspace' && buffer.length > cmdpos) {
                     buffer = buffer.substring(0,buffer.length-1);
                     charm.position(0,size[1])
-                        .erase('line')
-                        .column(0)
+                        .left(1)
+                        .erase('end')
                         .write(buffer);
 
                     LogWindow.log(buffer);
@@ -91,98 +109,115 @@ var InputWindow = (function(){
                         }
                     }
                     
-                } else if (key.charCodeAt() === 13) {
-                    if (buffer.length > 1) {
+                } else if (key.name === "return") {
+                    if (buffer.length > 1 || kb == 'emacs') {
+                        var args, cmd;
+                        if (buffer.substring(0,1) === ':')
+                            cmd = buffer.substring(cmdpos+1).split(' ', 1).join('').trim();
+                        else if (buffer.substring(0,1) != '/' && buffer.substring(0,10) != "I-search: ")
+                            cmd = buffer.substring(cmdpos).split(' ', 1).join('').trim();
+                        if(cmd) {
+                            args = buffer.substring(buffer.indexOf(cmd)+cmd.length+1).trim();
 
-                        if (buffer.substring(0,1) === ':') {
-                            var cmd = buffer.substring(1).split(' ', 1).join('').trim(),
-                                args = buffer.substring(buffer.indexOf(cmd)+cmd.length+1).trim();
                             switch (cmd.toLowerCase()) {
-                                case 't':
-                                    if (args.length) {
-                                        charm.erase('line');
-                                        setMode('normal');
-                                        HabitAPI.createTask("todo",args);
-                                        buffer = '';
-                                    }
-                                    break;
-                                case 'h':
-                                    if (args.length) {
-                                        charm.erase('line');
-                                        setMode('normal');
-                                        HabitAPI.createTask("habit",args);
-                                        buffer = '';
-                                    }
-                                    break;
-                                case 'd':
-                                    if (args.length) {
-                                        charm.erase('line');
-                                        setMode('normal');
-                                        HabitAPI.createTask("daily",args);
-                                        buffer = '';
-                                    }
-                                    break;
-                                case 'r':
-                                    if (args.length) {
-                                        charm.erase('line');
-                                        setMode('normal');
-                                        TaskList.renameTask(args);
-                                        buffer = '';
-                                    }
-                                    break;
-
-                                case 'delete':
+                            case 't':
+                                if (args.length) {
                                     charm.erase('line');
-                                    TaskList.deleteTask();
                                     setMode('normal');
-                                    buffer='';
-
-                                    break;
-
-                                case 'q':
-                                    process.exit(0);
-                                    break;
-                                default:
-                                    buffer='';
-                                    charm.erase('line')
-                                        .column(0)
-                                        .write('Unknown command: ' + cmd);
+                                    HabitAPI.createTask("todo",args);
+                                    buffer = '';
+                                }
+                                break;
+                            case 'h':
+                                if (args.length) {
+                                    charm.erase('line');
                                     setMode('normal');
+                                    HabitAPI.createTask("habit",args);
+                                    buffer = '';
+                                }
+                                break;
+                            case 'd':
+                                if (args.length) {
+                                    charm.erase('line');
+                                    setMode('normal');
+                                    HabitAPI.createTask("daily",args);
+                                    buffer = '';
+                                }
+                                break;
+                            case 'r':
+                                if (args.length) {
+                                    charm.erase('line');
+                                    setMode('normal');
+                                    TaskList.renameTask(args);
+                                    buffer = '';
+                                }
+                                break;
 
+                            case 'delete':
+                                charm.erase('line');
+                                TaskList.deleteTask();
+                                setMode('normal');
+                                buffer='';
+                            case 'emacs':
+                                setKeybinding('emacs');
+                                buffer='';
+                                setMode('normal');
+                                break;
+
+                            case 'vi':
+                                setKeybinding('vi');
+                                buffer='';
+                                setMode('normal');
+                                break;
+
+                            case 'q':
+                                process.exit(0);
+                                break;
+                            default:
+                                buffer='';
+                                charm.erase('line')
+                                    .column(0)
+                                    .write('Unknown command: ' + cmd);
+                                setMode('normal');
                             }
-                        } else if (buffer.substring(0,1) === '/') {
+                        } else if (buffer.substring(0,1) === '/' || buffer.substring(0,10) === "I-search: ") {
                             buffer='';
                             setMode('normal');
                             charm.erase('line');
 
-                            
                         }
                     }
 
-                } else if (key.charCodeAt() >= 32 && key.charCodeAt() <= 126 && buffer.length < size[0] - 4) {
-                    buffer = buffer + key;
+                } else if(!key.ctrl && !key.meta && buffer.length < size[0] - 4) {
+                    if(key.name == 'space')
+                        buffer = buffer + ' ';
+                    else if(key.name >= 'a' && key.name <= 'z') {
+                        if(key.name.length == '1')
+                            buffer = buffer + key.name;
+                    }
+                    else if(!key.name && key) // for those keys thats have no name
+                        buffer = buffer + key;
                     charm.position(0,size[1])
                         .write(buffer);
 
                     if(inputMode == 'search'){
-                        if(buffer.substring(1).length > 0){
+                        charm.cursor(false);
+                        if(buffer.substring(1).length > 0 && kb == 'vi'){
                             TaskList.searchCursor(buffer.substring(1));
-                        }
+                        } else if (kb == 'emacs')
+                            TaskList.searchCursor(buffer.substring(10));
                     }
                     
-                } else if (key.charCodeAt() === 27) { // esc
+                } else if (key.name == 'escape' || (key.ctrl && key.name == 'g')) { // esc or C-g
                     buffer = '';
                     charm.position(0,size[1])
                         .erase('line');
-                            
                     setMode('normal');
-
                 }
 
             }
         }
-
-    }
+}
 
 })();
 
@@ -345,15 +380,17 @@ var LogWindow = (function(){
             refresh();
             
         },
-        
+    
         // I got tired of key presses filling up my log.  Make a distinct line for it
         keyPress: function(key){
-
-            if(key.charCodeAt() > 44 && key.charCodeAt() < 127){
-                keyPress = "Pressed key: " + key;
-            } else {
-                keyPress = "Pressed key: /" + key.charCodeAt();
-            }
+            if(key.name)
+                keyPress =  key.name;
+            else 
+                keyPress = key;
+            if(key.ctrl)
+                keyPress = "C-" + keyPress;
+            else if(key.meta)
+                keyPress = "M-" + keyPress;
             refresh();
         },
         refresh: refresh,
@@ -816,69 +853,137 @@ var HelpWindow = (function(){
 
         if(hidden) return true;
         charm.push();
-
-        charm.position(7,12)
-            .erase('line')
-            .write('KEY  DESCRIPTION')
-            .move(0,1)
-            .erase('line')
-            .move(0,1)
-            .column(7)
-            .erase('line')
-            .write('  j  down a line')
-            .move(0,1)
-            .column(7)
-            .erase('line')
-            .write('  k  up a line')
-            .move(0,1)
-            .column(7)
-            .erase('line')
-            .write('spc  check off something')
-            .move(0,1)
-            .column(7)
-            .erase('line')
-            .write('  -  mark down a habit')
-            .move(0,1)
-            .column(7)
-            .erase('line')
-            .write('  ~  delete log')
-            .move(0,1)
-            .column(7)
-            .erase('line')
-            .write('  /  search tasks')
-            .move(0,1)
-            .erase('line')
-            .move(0,1)
-            .column(7)
-            .erase('line')
-            .write('  :q  quits')
-            .move(0,1)
-            .column(7)
-            .erase('line')
-            .write('  :h  add a habit')
-            .move(0,1)
-            .column(7)
-            .erase('line')
-            .write('  :d  add a daily')
-            .move(0,1)
-            .column(7)
-            .erase('line')
-            .write('  :delete    you can guess')
-            .move(0,1)
-            .erase('line');
-
-        drawBox(5,10,size[0]-8,16); 
-        charm.pop();
-    }
-
-    return {
-        refresh: refresh,
-        toggle: function(){
-            hidden = !hidden;
-            TaskList.refresh();
-            refresh();
+        if(kb == 'vi'){
+            charm.position(7,12)
+                .erase('line')
+                .write('KEY  DESCRIPTION')
+                .move(0,1)
+                .erase('line')
+                .move(0,1)
+                .column(7)
+                .erase('line')
+                .write('  j  down a line')
+                .move(0,1)
+                .column(7)
+                .erase('line')
+                .write('  k  up a line')
+                .move(0,1)
+                .column(7)
+                .erase('line')
+                .write('spc  check off something')
+                .move(0,1)
+                .column(7)
+                .erase('line')
+                .write('  -  mark down a habit')
+                .move(0,1)
+                .column(7)
+                .erase('line')
+                .write('  ~  delete log')
+                .move(0,1)
+                .column(7)
+                .erase('line')
+                .write('  /  search tasks')
+                .move(0,1)
+                .erase('line')
+                .move(0,1)
+                .column(7)
+                .erase('line')
+                .write('  :q  quits')
+                .move(0,1)
+                .column(7)
+                .erase('line')
+                .write('  :h  add a habit')
+                .move(0,1)
+                .column(7)
+                .erase('line')
+                .write('  :d  add a daily')
+                .move(0,1)
+                .column(7)
+                .erase('line')
+                .write('  :delete    you can guess')
+                .move(0,1)
+                .column(7)
+                .erase('line')
+                .write('  :vi    vi style keys')
+                .move(0,1)
+                .column(7)
+                .erase('line')
+                .write('  :emacs    emacs style keys')
+                .move(0,1)
+                .erase('line');
         }
+        if(kb == 'emacs'){
+            charm.position(7,12)
+                .erase('line')
+                .write('KEY  DESCRIPTION')
+                .move(0,1)
+                .erase('line')
+                .move(0,1)
+                .column(7)
+                .erase('line')
+                .write('  n or C-n  down a line')
+                .move(0,1)
+                .column(7)
+                .erase('line')
+                .write('  p or C-p  up a line')
+                .move(0,1)
+                .column(7)
+                .erase('line')
+                .write('  C-spc  check off something')
+                .move(0,1)
+                .column(7)
+                .erase('line')
+                .write('  C-d  mark down a habit')
+                .move(0,1)
+                .column(7)
+                .erase('line')
+                .write('  ~  delete log')
+                .move(0,1)
+                .column(7)
+                .erase('line')
+                .write('  C-s  search tasks')
+                .move(0,1)
+                .erase('line')
+                .move(0,1)
+                .column(7)
+                .erase('line')
+                .write('  M-x q  quits')
+                .move(0,1)
+                .column(7)
+                .erase('line')
+                .write('  M-x h  add a habit')
+                .move(0,1)
+                .column(7)
+                .erase('line')
+                .write('  M-x d  add a daily')
+                .move(0,1)
+                .column(7)
+                .erase('line')
+                .write('  M-x delete    you can guess')
+                .move(0,1)
+                .column(7)
+                .erase('line')
+                .write('  M-x vi    vi style keys')
+                .move(0,1)
+                .column(7)
+                .erase('line')
+                .write('  M-x emacs    emacs style keys')
+                .move(0,1)
+                .erase('line');
+        }
+
+drawBox(5,10,size[0]-8,18); 
+charm.pop();
+}
+
+return {
+    refresh: refresh,
+    toggle: function(){
+        hidden = !hidden;
+        TaskList.refresh();
+        refresh();
     }
+}
 })();
 
 InputWindow.setMode('normal');

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "superagent": "*",
     "nconf": "*",
     "underscore": "*",
-    "charm": "*"
+    "charm": "*",
+    "keypress": "*"
   },
   "main": "./index.js",
   "engines": { "node": ">0.6.0" },


### PR DESCRIPTION
This is a bit of a big change. I wanted to have emacs keybindings but it was really hard to get it working with the javascript keycodes. So this requires the keypress module, which doesn't change the current way keys are detected too much, but does make it a bit easier to read (instead of using key codes). You can switch keybindings with the emacs and vi commands. 

Hopefully some of these changes are useful! I'd be happy to change anything if needed. 
